### PR TITLE
Angepasst auf heli-X Version 6

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,11 +3,11 @@ Section: misc
 Priority: optional
 Maintainer: Arno Esser <arno.esser@dachsweb.de>
 Uploaders: Holger Schvestka <hotzenplotz5@gmx.de>
-Standards-Version: 0.0.1
+Standards-Version: 0.0.2
 Build-Depends: debhelper (>= 7), cdbs
 
 Package: yavdr-addon-helix
 Architecture: all
-Depends: ${yavdr-startup},${misc:Depends}, yavdr-utils, openjdk-6-jre, libopenal1, unzip
+Depends: ${yavdr-startup},${misc:Depends}, yavdr-utils, openjdk-7-jre, libopenal1
 Description: yavdr-addon-helix
  yavdr-addon-helix

--- a/debian/postrm
+++ b/debian/postrm
@@ -3,8 +3,8 @@
 if [ remove = "$1" ]; then 
 	/usr/bin/signal-event addons-update
 
-	rm -rf /opt/HELI-X30
-	rm -f /opt/HELI-X30.zip
+	rm -rf /opt/HELI-X*
+	rm -f /opt/HELI-X*
 
 fi
 

--- a/debian/preinst
+++ b/debian/preinst
@@ -2,11 +2,11 @@
 
 if [ install = "$1" -o upgrade = "$1" ]; then 
 	cd /opt        
-	rm -f /opt/HELI-X30.zip
-	wget http://www.heli-x.info/30/HELI-X30.zip
-	unzip HELI-X30.zip
-	chown -R vdr.vdr HELI-X30
-	chmod 555 HELI-X30/runHELI-X64.sh
+	rm -f /opt/HELI-X*.tar.gz
+	wget http://www.heli-x.info/1616/HELI-X6.tar.gz
+	tar xzf HELI-X6.tar.gz
+	chown -R vdr.vdr HELI-X6
+	chmod 555 HELI-X6/runHELI-X.sh
 	echo "Installing demo version of HELI-X flight simulator"
 fi
 

--- a/templates/etc/init/helix.conf/10_main
+++ b/templates/etc/init/helix.conf/10_main
@@ -14,5 +14,5 @@ vdr-dbus-send /Remote remote.Enable ||:
 /sbin/initctl emit --no-wait vdr-frontend-restart
 end script
 
-exec su -c "/opt/HELI-X30/runHELI-X.sh" vdr
+exec su -c "/opt/HELI-X6/runHELI-X.sh" vdr
 


### PR DESCRIPTION
Mal angepasst an die momentan aktuelle Heli-X-Version.
Dependencies unzip raus (ist jetzt tar.gz) und openjdk-7-jre rein.